### PR TITLE
ci: add basic CI with valgrind and build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Minishell CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y valgrind libreadline-dev
+
+    - name: Compile the project
+      run: make
+
+    - name: Run valgrind check (simple test)
+      run: |
+        echo "exit" | valgrind --leak-check=full --show-leak-kinds=all ./minishell


### PR DESCRIPTION
# 📦 Pull Request

## ✨ What’s this PR about?
Adding a basic CI which will allow us to automatize a valgrind and build check before the PR is made.

## 🔗 Related issues / features
CI

## 🧪 How to test it?
It's automitazed to do every time we make a PR, if it fails, the PR fails.

## ✅ Checklist
- [x] Code compiles with `make`
- [x] Feature works as intended
- [x] No memory leaks (run `valgrind`)
- [x] PR reviewed and approved
- [x] All conversations resolved

## 💬 Notes
<!-- Anything extra reviewers should know -->
